### PR TITLE
feat: add support for both tag-based and manual releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -22,11 +25,17 @@ jobs:
 
       - name: Prepare environment
         run: |
-          # Use commit hash as version for all releases
-          COMMIT_HASH="${{ github.sha }}"
-          SHORT_HASH="${COMMIT_HASH:0:8}"
-          TAG="${SHORT_HASH}"
-          echo "Creating release for commit: $TAG"
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            # Use tag name for automatic releases
+            TAG="${{ github.ref_name }}"
+            echo "Creating release for tag: $TAG"
+          else
+            # Use commit hash for manual releases
+            COMMIT_HASH="${{ github.sha }}"
+            SHORT_HASH="${COMMIT_HASH:0:8}"
+            TAG="${SHORT_HASH}"
+            echo "Creating release for commit: $TAG"
+          fi
           BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           echo "TAG=$TAG" >> $GITHUB_ENV
           echo "BUILD_TIME=$BUILD_TIME" >> $GITHUB_ENV
@@ -86,7 +95,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: Negev ${{ env.TAG }}
-          tag_name: release-${{ env.TAG }}
+          tag_name: ${{ env.TAG }}
           generate_release_notes: true
           files: |
             dist/negev_${{ env.TAG }}_linux_amd64.tar.gz


### PR DESCRIPTION
- Restore automatic tag triggers for v* tags
- Use tag name as version for automatic releases
- Use commit hash for manual releases
- Maintain flexibility for both release types