### PR TITLE
feat: improve CLI flags and remove skip VLAN check option

### DIFF
--- a/README-PT.md
+++ b/README-PT.md
@@ -10,14 +10,13 @@
 - **Gerenciamento SSH**: Conecta-se a switches Cisco via SSH quando Telnet está desabilitado ou não é desejado.
 - **Atribuição de VLAN Baseada em MAC**: Atribui VLANs com base nos primeiros três bytes de endereços MAC, com uma VLAN padrão para dispositivos não mapeados.
 - **Modo Sandbox**: Simula alterações de configuração sem aplicá-las ao switch.
-- **Persistência de Configuração**: Salva alterações na configuração em execução do switch (com flag `-w`).
+- **Persistência de Configuração**: Salva alterações na configuração em execução do switch (com flag `--write`).
 - **Exclusão de MAC**: Ignora endereços MAC especificados durante a atribuição de VLAN.
 - **Exclusão de Portas**: Permite pular interfaces que nunca devem ser tocadas.
 - **Detecção de Interface Trunk**: Ignora automaticamente interfaces trunk para evitar configuração incorreta.
-- **Criação de VLAN**: Opcionalmente cria VLANs ausentes no switch (com flag `-c`).
-- **Logging Detalhado**: Fornece saída de debug detalhada para solução de problemas (use `-v 1`).
-- **Exibição de Saída Bruta**: Mostra saídas brutas do switch para debug (use `-v 2` ou `-v 3`).
-- **Validação de VLAN**: Opcionalmente pula verificações de existência de VLAN (com flag `-s`).
+- **Criação de VLAN**: Opcionalmente cria VLANs ausentes no switch (com flag `--create-vlans`).
+- **Logging Detalhado**: Fornece saída de debug detalhada para solução de problemas (use `--verbose 1`).
+- **Exibição de Saída Bruta**: Mostra saídas brutas do switch para debug (use `--verbose 2` ou `--verbose 3`).
 
 ## Manuais do Usuário
 
@@ -38,7 +37,7 @@ Ou use os helpers do Makefile (recomendado):
 
 ```bash
 make build
-./bin/negev -t 192.168.1.1
+./bin/negev --target 192.168.1.1
 ```
 
 ## Configuração
@@ -98,13 +97,13 @@ switches:
 ## ⚠️ Segurança
 
 - **Telnet** Telnet é inseguro e transmite credenciais em texto plano. Use apenas em redes confiáveis.
-- **Modo Sandbox** Sempre teste em modo sandbox (padrão) antes de aplicar alterações com -w.
+- **Modo Sandbox** Sempre teste em modo sandbox (padrão) antes de aplicar alterações com --write.
 - **Credenciais** Armazene informações sensíveis (username, password, enable_password) com segurança.
 
 ## Limitações
 
 - **Transporte** Telnet é o padrão; suporte SSH depende do dispositivo ter uma CLI interativa similar ao Telnet.
-- **Switch Único** Cada execução processa um switch (especificado com `-t`).
+- **Switch Único** Cada execução processa um switch (especificado com `--target`).
 - **Sem Reversão** Alterações não são revertidas automaticamente em caso de falha.
 - **MAC Único por Porta** Portas com múltiplos endereços MAC são ignoradas para evitar ambiguidade.
 - **Parse de Saída do Switch** A ferramenta assume formatos de saída padrão de switches Cisco; formatos inesperados podem causar erros de parse.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make build
 
 The configuration is defined in a YAML file, specifying the default VLAN, MAC-to-VLAN mappings, and exclusions. A full sample lives in `examples/config.yaml`. Below is an excerpt:
 
-```bash
+```yaml
 transport: "telnet"
 username: "admin"
 password: "password"

--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@
 - **SSH Management**: Connects to Cisco switches via SSH when Telnet is disabled or undesired.
 - **MAC-Based VLAN Assignment**: Assigns VLANs based on the first three bytes of MAC addresses, with a default VLAN for unmapped devices.
 - **Sandbox Mode**: Simulates configuration changes without applying them to the switch.
-- **Configuration Persistence**: Saves changes to the switch's running configuration (with `-w` flag).
+- **Configuration Persistence**: Saves changes to the switch's running configuration (with `--write` flag).
 - **MAC Exclusion**: Ignores specified MAC addresses during VLAN assignment.
 - **Port Exclusion**: Lets you skip interfaces that should never be touched.
 - **Trunk Interface Detection**: Automatically skips trunk interfaces to avoid misconfiguration.
-- **VLAN Creation**: Optionally creates missing VLANs on the switch (with `-c` flag).
-- **Verbose Logging**: Provides detailed debug output for troubleshooting (use `-v 1`).
-- **Raw Output Display**: Shows raw switch outputs for debugging (use `-v 2` or `-v 3`).
-- **VLAN Validation**: Optionally skips VLAN existence checks (with `-s` flag).
+- **VLAN Creation**: Optionally creates missing VLANs on the switch (with `--create-vlans` flag).
+- **Verbose Logging**: Provides detailed debug output for troubleshooting (use `--verbose 1`).
+- **Raw Output Display**: Shows raw switch outputs for debugging (use `--verbose 2` or `--verbose 3`).
 
 ## User Manuals
 
@@ -38,7 +37,7 @@ Or rely on the Makefile helpers (recommended):
 
 ```bash
 make build
-./bin/negev -t 192.168.1.1
+./bin/negev --target 192.168.1.1
 ```
 
 ## Configuration
@@ -98,13 +97,13 @@ switches:
 ## Security
 
 - **Telnet** Telnet is insecure and transmits credentials in plain text. Use only on trusted networks.
-- **Sandbox Mode** Always test in sandbox mode (default) before applying changes with -w.
+- **Sandbox Mode** Always test in sandbox mode (default) before applying changes with --write.
 - **Credentials** Store sensitive information (username, password, enable_password) securely.
 
 ## Limitations
 
 - **Transport** Telnet is the default; SSH support depends on the device having an interactive CLI similar to Telnet.
-- **Single Switch** Each execution processes one switch (specified with `-t`).
+- **Single Switch** Each execution processes one switch (specified with `--target`).
 - **No Reversion** Changes are not automatically reverted in case of failure.
 - **Single MAC per Port** Ports with multiple MAC addresses are skipped to avoid ambiguity.
 - **Switch Output Parsing** The tool assumes standard Cisco switch output formats; unexpected formats may cause parsing errors.

--- a/core/cmd/negev/main.go
+++ b/core/cmd/negev/main.go
@@ -20,36 +20,34 @@ var (
 
 func printUsage() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
-	fmt.Fprintf(os.Stderr, "  -c          Sync VLANs on switch (create missing, delete extra)\n")
-	fmt.Fprintf(os.Stderr, "  -s          Skip VLAN existence check (use with caution)\n")
-	fmt.Fprintf(os.Stderr, "  -t string   Switch target (must match a target in YAML, required)\n")
-	fmt.Fprintf(os.Stderr, "  -v int      Verbosity level: 0=none, 1=debug logs, 2=raw switch output, 3=debug+raw output\n")
-	fmt.Fprintf(os.Stderr, "  -w          Apply changes (disables sandbox mode)\n")
-	fmt.Fprintf(os.Stderr, "  -y string   YAML configuration file (default \"config.yaml\")\n")
+	fmt.Fprintf(os.Stderr, "  --create-vlans     Sync VLANs on switch (create missing, delete extra)\n")
+	fmt.Fprintf(os.Stderr, "  --target string    Switch target (must match a target in YAML, required)\n")
+	fmt.Fprintf(os.Stderr, "  --verbose int      Verbosity level: 0=none, 1=debug logs, 2=raw switch output, 3=debug+raw output\n")
+	fmt.Fprintf(os.Stderr, "  --write            Apply changes (disables sandbox mode)\n")
+	fmt.Fprintf(os.Stderr, "  --config string    YAML configuration file (default \"config.yaml\")\n")
 }
 
 func main() {
 	flag.Usage = printUsage
-	yamlFile := flag.String("y", "config.yaml", "YAML configuration file")
-	write := flag.Bool("w", false, "Apply changes (disables sandbox mode)")
-	verbosity := flag.Int("v", 0, "Verbosity level: 0=none, 1=debug logs, 2=raw switch output, 3=debug+raw output")
-	host := flag.String("t", "", "Switch target (must match a target in YAML, required)")
-	skipVlanCheck := flag.Bool("s", false, "Skip VLAN existence check (use with caution)")
-	createVLANs := flag.Bool("c", false, "Sync VLANs on switch (create missing, delete extra)")
+	yamlFile := flag.String("config", "config.yaml", "YAML configuration file")
+	write := flag.Bool("write", false, "Apply changes (disables sandbox mode)")
+	verbosity := flag.Int("verbose", 0, "Verbosity level: 0=none, 1=debug logs, 2=raw switch output, 3=debug+raw output")
+	host := flag.String("target", "", "Switch target (must match a target in YAML, required)")
+	createVLANs := flag.Bool("create-vlans", false, "Sync VLANs on switch (create missing, delete extra)")
 	flag.Parse()
 
 	fmt.Printf("Negev %s (built %s)\n", version, buildTime)
 
 	// Validate verbosity level
 	if *verbosity < 0 || *verbosity > 3 {
-		fmt.Fprintf(os.Stderr, "Error: -v must be 0, 1, 2, or 3\n")
+		fmt.Fprintf(os.Stderr, "Error: --verbose must be 0, 1, 2, or 3\n")
 		flag.Usage()
 		os.Exit(1)
 	}
 
-	// Check if -t parameter is provided
+	// Check if --target parameter is provided
 	if *host == "" {
-		fmt.Fprintf(os.Stderr, "Error: the -t parameter is required. Specify the switch target with -t <target>\n")
+		fmt.Fprintf(os.Stderr, "Error: the --target parameter is required. Specify the switch target with --target <target>\n")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -101,7 +99,7 @@ func main() {
 	}
 
 	// Load configuration, passing the target switch IP for log filtering
-	cfg, err := config.Load(configPath, *host, *write, *verbosity, *skipVlanCheck, *createVLANs)
+	cfg, err := config.Load(configPath, *host, *write, *verbosity, *createVLANs)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/core/domain/entities/switch_config.go
+++ b/core/domain/entities/switch_config.go
@@ -16,7 +16,6 @@ type SwitchConfig struct {
 	ProtectedVlans []string          `yaml:"protected_vlans"`
 	Sandbox        bool
 	VerbosityLevel int
-	SkipVlanCheck  bool
 	CreateVLANs    bool
 }
 

--- a/core/domain/services/vlan_service.go
+++ b/core/domain/services/vlan_service.go
@@ -328,7 +328,7 @@ func (v *VLANServiceImpl) GetMacTable() ([]entities.Device, error) {
 	return devices, nil
 }
 
-// ConfigureVlan configura VLAN em uma interface
+// ConfigureVlan configures VLAN on an interface
 func (v *VLANServiceImpl) ConfigureVlan(iface, vlan string) {
 	commands := []string{
 		"configure terminal",

--- a/core/domain/services/vlan_service.go
+++ b/core/domain/services/vlan_service.go
@@ -152,7 +152,7 @@ func (v *VLANServiceImpl) ProcessPorts() error {
 			fmt.Printf("DEBUG: MAC %s (prefix %s) maps to VLAN %s\n", dev.MacFull, macPrefix, targetVlan)
 		}
 
-		if !v.config.SkipVlanCheck && !existingVLANs[targetVlan] {
+		if !existingVLANs[targetVlan] {
 			log.Printf("Error: VLAN %s does not exist on switch, ignoring port %s", targetVlan, port.Interface)
 			continue
 		}

--- a/core/infrastructure/config/config_loader.go
+++ b/core/infrastructure/config/config_loader.go
@@ -31,7 +31,7 @@ func NormalizeMAC(mac string) string {
 }
 
 // Load loads and validates configuration from a YAML file
-func Load(yamlFile, target string, sandbox bool, verbosityLevel int, skipVlanCheck, createVLANs bool) (*Config, error) {
+func Load(yamlFile, target string, sandbox bool, verbosityLevel int, createVLANs bool) (*Config, error) {
 	data, err := os.ReadFile(yamlFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read YAML file %s: %v", yamlFile, err)
@@ -291,7 +291,6 @@ func Load(yamlFile, target string, sandbox bool, verbosityLevel int, skipVlanChe
 
 		sw.Sandbox = !sandbox
 		sw.VerbosityLevel = verbosityLevel
-		sw.SkipVlanCheck = skipVlanCheck
 		sw.CreateVLANs = createVLANs
 
 		if switchVerbosity == 1 || switchVerbosity == 3 {

--- a/docs/GUIDE-PT.md
+++ b/docs/GUIDE-PT.md
@@ -5,7 +5,7 @@ Este manual mostra como operar o **Negev** depois de ter o binário disponível.
 ## 1. Visão Geral
 - Negev automatiza a atribuição de VLAN em switches Cisco usando Telnet ou SSH.
 - As decisões se baseiam em prefixos de MAC, exclusões explícitas e VLAN padrão.
-- Por padrão, Negev roda em *modo sandbox* (apenas simula). Use `-w` para aplicar mudanças de verdade.
+- Por padrão, Negev roda em *modo sandbox* (apenas simula). Use `--write` para aplicar mudanças de verdade.
 
 ## 2. Arquivos Necessários
 - **Binário**: `negev` (baixado do release do GitHub ou outra distribuição sua).
@@ -56,7 +56,7 @@ switches:
       "00:c8:8b": "70"
 ```
 
-- `target` é obrigatório e deve bater com o `-t` na hora de rodar.
+- `target` é obrigatório e deve bater com o `--target` na hora de rodar.
 - `transport`, credenciais e VLANs definidas aqui substituem os valores globais só para esse switch.
 - `exclude_ports` (não diferencia maiúsculas/minúsculas) evita que o Negev toque em portas sensíveis.
 - Ao mesclar, as regras do switch têm prioridade sobre as globais para o mesmo prefixo.
@@ -70,33 +70,32 @@ switches:
 ## 4. Rodando o Negev
 Comando básico:
 ```bash
-negev -t 192.168.1.10
+negev --target 192.168.1.10
 ```
 
 ### Flags Úteis
-- `-y caminho/arquivo.yaml` usa outro arquivo de configuração.
-- `-w` aplica mudanças (sem essa flag o Negev apenas simula).
-- `-v 1` mostra logs de debug (decisões de merge, exclusões).
-- `-v 2` exibe saída crua do switch.
-- `-v 3` junta debug e saída crua.
-- `-s` ignora validação de existência de VLAN (use apenas se tiver certeza do que está fazendo).
-- `-c` cria VLANs exigidas pelas regras quando não existem no switch.
+- `--config caminho/arquivo.yaml` usa outro arquivo de configuração.
+- `--write` aplica mudanças (sem essa flag o Negev apenas simula).
+- `--verbose 1` mostra logs de debug (decisões de merge, exclusões).
+- `--verbose 2` exibe saída crua do switch.
+- `--verbose 3` junta debug e saída crua.
+- `--create-vlans` cria VLANs exigidas pelas regras quando não existem no switch.
 
 ### Fluxo Sugerido
 1. Rode primeiro em modo sandbox para revisar:
    ```bash
-   negev -t 192.168.1.10 -v 1
+   negev --target 192.168.1.10 --verbose 1
    ```
 2. Se o relatório estiver correto, execute com aplicação real:
    ```bash
-   negev -t 192.168.1.10 -w -v 1
+   negev --target 192.168.1.10 --write --verbose 1
    ```
 
 ### Interpretando a Saída
 - Linhas com `SANDBOX` mostram os comandos que seriam executados.
 - `Configured Gi1/0/1 to VLAN 20` confirma uma mudança bem sucedida.
 - `Warning: Multiple MACs...` indica que a porta foi ignorada para evitar risco.
-- `Error: VLAN 50 does not exist` mostra que a VLAN precisa ser criada (use `-c` se fizer sentido).
+- `Error: VLAN 50 does not exist` mostra que a VLAN precisa ser criada (use `--create-vlans` se fizer sentido).
 
 ## 5. Mantendo a Configuração
 - Versione o YAML sem dados sensíveis.
@@ -108,20 +107,20 @@ negev -t 192.168.1.10
 | Sintoma | Possível Causa | Ação sugerida |
 | --- | --- | --- |
 | "target ... not registered" | Switch não está na lista | Verifique se o IP está em `switches` com a grafia correta |
-| "No devices found" | Switch não retornou tabela MAC | Confirme se o comando existe no modelo; tente `-v 2` para ver a resposta |
+| "No devices found" | Switch não retornou tabela MAC | Confirme se o comando existe no modelo; tente `--verbose 2` para ver a resposta |
 | Erros de SSH | Credenciais erradas ou SSH bloqueado | Revise usuário/senha, habilite SSH ou use Telnet temporariamente |
 | VLAN repetindo | Switch reverte ou há múltiplos MACs | Verifique trunks, porta com múltiplos MACs ou políticas de segurança |
 
 ## 7. Perguntas Frequentes
-- **Posso rodar em vários switches ao mesmo tempo?** Não. Execute o Negev uma vez por switch com o `-t` correto.
-- **Dá para simular mesmo com `-w`?** Não. Sem `-w`, sempre sandbox. Para aplicar execute novamente com `-w`.
+- **Posso rodar em vários switches ao mesmo tempo?** Não. Execute o Negev uma vez por switch com o `--target` correto.
+- **Dá para simular mesmo com `--write`?** Não. Sem `--write`, sempre sandbox. Para aplicar execute novamente com `--write`.
 - **Negev mexe em portas trunk?** Não. Ele detecta trunk e ignora.
 - **E portas com mais de um MAC?** São ignoradas para não arriscar configurações erradas.
 
 ## 8. Checklist Antes de Aplicar
-- As VLANs necessárias já existem? Caso contrário, pense em usar `-c`.
+- As VLANs necessárias já existem? Caso contrário, pense em usar `--create-vlans`.
 - Portas críticas estão em `exclude_ports`?
 - Conferiu os prefixos (`aa:bb:c1` vs `aa:bb:c1`)?
-- Em ambientes sensíveis, rode com `-v 3` na primeira execução real.
+- Em ambientes sensíveis, rode com `--verbose 3` na primeira execução real.
 
 Seguindo esse manual você ganha mais confiança no uso do Negev, ajustando VLANs com menos esforço e risco.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5,7 +5,7 @@ This manual explains how to operate **Negev** once the binary is available. It f
 ## 1. Quick Overview
 - Negev automates VLAN assignments on Cisco switches using Telnet or SSH.
 - Decisions are based on MAC address prefixes, explicit exclusions, and default VLAN rules.
-- By default, Negev works in *sandbox mode* (simulation only). Add `-w` to apply changes.
+- By default, Negev works in *sandbox mode* (simulation only). Add `--write` to apply changes.
 
 ## 2. Required Files
 - **Binary**: `negev` (obtained from the GitHub release or other distribution).
@@ -56,7 +56,7 @@ switches:
       "00:c8:8b": "70"
 ```
 
-- `target` is mandatory and must match the `-t` flag when running Negev.
+- `target` is mandatory and must match the `--target` flag when running Negev.
 - `transport`, credentials, and VLAN settings override global values only for that switch.
 - `exclude_ports` (case-insensitive) prevents Negev from touching sensitive interfaces.
 - Merge logic: switch mappings take precedence over global mappings for the same prefix.
@@ -70,33 +70,32 @@ switches:
 ## 4. Running Negev
 Basic command:
 ```bash
-negev -t 192.168.1.10
+negev --target 192.168.1.10
 ```
 
 ### Useful Flags
-- `-y path/file.yaml` use a custom configuration path.
-- `-w` apply changes instead of simulating.
-- `-v 1` enable debug logs (merge decisions, exclusions).
-- `-v 2` show raw switch output.
-- `-v 3` enable both debug and raw logs.
-- `-s` skip VLAN existence check (risky; use only if you know the VLAN is missing intentionally).
-- `-c` create VLANs that are required by the mappings but absent on the switch.
+- `--config path/file.yaml` use a custom configuration path.
+- `--write` apply changes instead of simulating.
+- `--verbose 1` enable debug logs (merge decisions, exclusions).
+- `--verbose 2` show raw switch output.
+- `--verbose 3` enable both debug and raw logs.
+- `--create-vlans` create VLANs that are required by the mappings but absent on the switch.
 
 ### Typical Workflow
 1. Run in sandbox mode to review changes:
    ```bash
-   negev -t 192.168.1.10 -v 1
+   negev --target 192.168.1.10 --verbose 1
    ```
 2. If output looks correct, apply changes:
    ```bash
-   negev -t 192.168.1.10 -w -v 1
+   negev --target 192.168.1.10 --write --verbose 1
    ```
 
 ### Reading the Output
 - `SANDBOX: ...` lines show the commands that would run.
 - `Configured Gi1/0/1 to VLAN 20` confirms a successful change.
 - `Warning: Multiple MACs detected on port ...` means Negev skips that port to avoid mistakes.
-- `Error: VLAN 50 does not exist on the switch` indicates the VLAN must be created (use `-c` if appropriate).
+- `Error: VLAN 50 does not exist on the switch` indicates the VLAN must be created (use `--create-vlans` if appropriate).
 
 ## 5. Maintaining Configuration
 - Keep the YAML in version control without real passwords (use placeholders or environment variables).
@@ -108,20 +107,20 @@ negev -t 192.168.1.10
 | Symptom | Possible Cause | Suggested Action |
 | --- | --- | --- |
 | "target ... not registered" | Missing switch entry | Ensure the `switches` list contains the target IP and correct casing |
-| "No devices found" | Switch not reporting MAC table | Verify the switch supports the command; try `-v 2` to inspect raw output |
+| "No devices found" | Switch not reporting MAC table | Verify the switch supports the command; try `--verbose 2` to inspect raw output |
 | SSH errors | Credentials or host key issues | Confirm login data, allow SSH, or switch to Telnet temporarily |
 | VLAN mismatch keeps returning | Switch may revert changes or multiple devices exist | Check for trunk ports, port security, or multiple MACs warning |
 
 ## 7. Frequently Asked Questions
-- **Does Negev support multiple switches per run?** No. Run once per switch using `-t` with the desired target.
-- **Can I dry-run even with `-w` set?** No. Without `-w`, Negev always simulates. Use two runs: one sandbox, one real.
+- **Does Negev support multiple switches per run?** No. Run once per switch using `--target` with the desired target.
+- **Can I dry-run even with `--write` set?** No. Without `--write`, Negev always simulates. Use two runs: one sandbox, one real.
 - **How does Negev treat trunk ports?** It automatically detects them and skips adjustments.
 - **What happens to ports with more than one MAC?** They are ignored to avoid guessing the correct device.
 
 ## 8. Safety Checklist Before Applying Changes
-- Are the required VLANs already present? If not, consider `-c`.
+- Are the required VLANs already present? If not, consider `--create-vlans`.
 - Are all critical ports added to `exclude_ports`?
 - Did you review mappings for typos (`aa:bb:c1` vs `aa:bb:c1`)?
-- For sensitive environments, run with `-v 3` during the first deployment.
+- For sensitive environments, run with `--verbose 3` during the first deployment.
 
 Following this guide helps you keep VLAN assignments tidy while avoiding surprises. Adjust the configuration iteratively, monitor logs, and enjoy a more automated network routine.


### PR DESCRIPTION
## Summary
- Replace single-letter flags with descriptive names (--target, --write, --verbose, --config, --create-vlans)
- Remove -s flag (skip VLAN check) to simplify interface and reduce risk
- Update all documentation to reflect new flag names
- Remove SkipVlanCheck field from SwitchConfig entity
- Simplify VLAN validation logic by always checking existence

## Changes Made
### CLI Improvements
- `-t` → `--target` (switch IP address)
- `-w` → `--write` (apply changes)
- `-v` → `--verbose` (verbosity level 0-3)
- `-y` → `--config` (configuration file path)
- `-c` → `--create-vlans` (sync VLANs)

### Code Cleanup
- Removed `-s` flag functionality completely
- Eliminated `SkipVlanCheck` field from `SwitchConfig`
- Simplified VLAN validation logic
- Standardized all comments to English

### Documentation Updates
- Updated README.md and README-PT.md
- Updated docs/GUIDE.md and docs/GUIDE-PT.md
- Fixed YAML code block syntax in README.md
- All command examples use new descriptive flags

## Benefits
- **More intuitive**: Descriptive flag names are self-explanatory
- **Safer**: Removed risky option that could cause silent errors
- **Simpler**: Fewer flags to confuse users
- **Consistent**: Follows modern CLI standards
- **Better UX**: Easier to remember and use

## Testing
- All code compiles successfully
- CLI help shows correct new flags
- Documentation is consistent across all files
- No remaining references to old flags

## Breaking Changes
This is a breaking change for existing users who use the single-letter flags. They will need to update their scripts to use the new descriptive flag names.